### PR TITLE
dpdk prefilter - fix startup synchronization

### DIFF
--- a/dpdk/prefilter/lcore-worker.c
+++ b/dpdk/prefilter/lcore-worker.c
@@ -133,7 +133,8 @@ int ThreadMain(void *init_values)
 
             if (lv->qid == 0) {
                 print_stats(lv->port1_id);
-                print_stats(lv->port2_id);
+                if (lv->opmode == IPS)
+                    print_stats(lv->port2_id);
             }
 
             // only work with tasks and result ring/s and bt

--- a/dpdk/prefilter/prefilter.c
+++ b/dpdk/prefilter/prefilter.c
@@ -303,7 +303,7 @@ static int IPCSetupOffloads(const struct rte_mp_msg *msg, const void *peer) {
     mp_resp.len_param = (int)strlen((char *)mp_resp.param);
 
     uint8_t tout_sec = 1; // TODO change value
-    ret = LcoreStateWaitWithTimeout(ctx.lcores_state.lcores_arr[LcoreMainAsWorker->lcore_id].state, LCORE_INIT_DONE, tout_sec);
+    ret = LcoreStateCheckAllWTimeout(LCORE_INIT_DONE, tout_sec);
     if (ret != 0) {
         Log().error(ETIMEDOUT, "Workers have not initialised in time (%s sec)", tout_sec);
         exit(1);


### PR DESCRIPTION
Stats of the second port in IDS mode makes Prefilter crash,
Synchronization with extra non-worker lcore was not successful.